### PR TITLE
Fix xml netlist to use preferred (high level) label for hierarchical …

### DIFF
--- a/src/NetList.cpp
+++ b/src/NetList.cpp
@@ -2267,9 +2267,9 @@ void CNetList::rawWriteNetListFileXML(CTinyCadMultiDoc *pDesign, std::ofstream& 
 			CNetListNode& theNode = *nv_it;
 			++nv_it;
 
-			if (netname == NULL && !theNode.getLabel().IsEmpty())
+			if (netname == NULL && !theNode.getPreferredLabel().IsEmpty())
 			{
-				netname = doc.allocate_string(theNode.getLabel());
+				netname = doc.allocate_string(theNode.getPreferredLabel());
 			}
 
 			if (theNode.m_parent != NULL && theNode.m_parent->GetType() == xPinEx)


### PR DESCRIPTION
…nets, instead of a lower level label.

Nets in XML netlists of hierarchical designs with multiple lower level diagrams and interconnecting wires got the name of one of the lower levels instead of the common highest level  label. This small change fixes that.