### PR TITLE
Use image size on bitmap paste

### DIFF
--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -243,6 +243,8 @@ void CTinyCadView::OnEditPaste()
 		CDrawMetaFile *pObject = new CDrawMetaFile(GetCurrentDocument());
 		if (pObject->setBitmap(bitmap))
 		{
+			CClientDC dc(this);
+			pObject->determineSize(dc);
 			GetCurrentDocument()->AddImage(pObject);
 		}
 	}


### PR DESCRIPTION
Paste did not retain an image original size and used always fixed rectangular 100x100 pixel size.