### PR TITLE
Paint white fill as white when B&W printing is checked

### DIFF
--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -345,7 +345,11 @@ BOOL CContext::SelectBrush(COLORREF Colour, int Index)
 {
 	//int Selected = -1;
 
-	if (allBlack) Colour = RGB(0,0,0);
+	constexpr COLORREF cWhite = RGB(255, 255, 255);
+	constexpr COLORREF cBlack = RGB(0, 0, 0);
+
+	// If painting all back and if any other colour than white override the colour
+	if (allBlack && Colour != cWhite) Colour = cBlack;	
 
 	// Does this brush already exist?
 	brush_map::iterator itb = m_brushes.find(sBrush(Colour, Index));


### PR DESCRIPTION
Brush selection does not override white color as black when original colour is white.
This fixes most white objects being printed as solid black.