### PR TITLE
Close edit dialog when user presses Esc

### DIFF
--- a/src/Diag.h
+++ b/src/Diag.h
@@ -135,9 +135,7 @@ public:
 protected:
 	virtual void DoDataExchange(CDataExchange* pDX); // DDX/DDV support
 	//}}AFX_VIRTUAL
-
-	// Implementation
-protected:
+	void OnCancel() override;
 
 private:
 	CDrawingObject *m_pObject;

--- a/src/EditDlg.cpp
+++ b/src/EditDlg.cpp
@@ -47,6 +47,20 @@ void CEditDlg::DoDataExchange(CDataExchange* pDX)
 	//}}AFX_DATA_MAP
 }
 
+void CEditDlg::OnCancel()
+{	
+	// This member is called when edit dialog is in focus and user presses VK_ESCAPE.
+	// Process this situation in the same way as what would happen if the main application window would
+	// have been in focus and user pressed VK_ESCAPE.
+
+	extern CTinyCadView *g_currentview;
+
+	if (g_currentview) {
+		// CTinyCadView maps the VK_ESCAPE to this command
+		g_currentview->SendMessage(WM_COMMAND, IDM_EDITEDIT, 0);
+	}
+}
+
 BEGIN_MESSAGE_MAP(CEditDlg, CDialog)
 //{{AFX_MSG_MAP(CEditDlg)
 // No message handlers


### PR DESCRIPTION
Previously Esc was ignored if the edit dialog was in focus.