### PR TITLE
Metafiles are checked last for selectability

### DIFF
--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -197,7 +197,7 @@ BOOL CContext::SelectPen(int Style, int Width, LONG Colour, paint_options option
 			COLORREF col = Colour;
 
 			// Calculate a rough appearent luminosity of the color.
-			// The human eye is not very sensitive to the color blue, 
+			// The human eye is not very sensitive to the color blue,
 			// that's why its contribution in the calculation is halved.
 			if (GetRValue(col) + GetGValue(col) + (GetBValue(col) >> 1) < (3 * 128))
 			{
@@ -349,7 +349,7 @@ BOOL CContext::SelectBrush(COLORREF Colour, int Index)
 	constexpr COLORREF cBlack = RGB(0, 0, 0);
 
 	// If painting all back and if any other colour than white override the colour
-	if (allBlack && Colour != cWhite) Colour = cBlack;	
+	if (allBlack && Colour != cWhite) Colour = cBlack;
 
 	// Does this brush already exist?
 	brush_map::iterator itb = m_brushes.find(sBrush(Colour, Index));
@@ -567,13 +567,13 @@ void CContext::Polyline(pointCollection &points, CDPoint offset, FillStyle *pSty
 		int brushorigin = 0;
 		// Find top-left point, which is set as brush origin.
 		// This is needed to work around a bug in the GDI hatch fill pattern.
-		for (int i=1; i < n; i++) 
+		for (int i=1; i < n; i++)
 		{
-			if (lpPoints[i].x < lpPoints[brushorigin].x) 
+			if (lpPoints[i].x < lpPoints[brushorigin].x)
 			{
 				brushorigin = i;
 			}
-			else if (lpPoints[i].x == lpPoints[brushorigin].x && 
+			else if (lpPoints[i].x == lpPoints[brushorigin].x &&
 				lpPoints[i].y < lpPoints[brushorigin].y)
 			{
 				brushorigin = i;
@@ -668,7 +668,7 @@ void CContext::TextOut(double x, double y, const TCHAR *t)
 }
 
 // Display the text on the screen with kerning and overbars.
-// This is used to display user entered annotation text (i.e., single line text strings), 
+// This is used to display user entered annotation text (i.e., single line text strings),
 // pin names and numbers, parameters, net labels, etc.
 // This is the primary method of displaying most text objects.
 void CContext::TextOut(CString text, CDPoint da, paint_options options, int dir)
@@ -853,7 +853,7 @@ void CContext::TextOut(CString text, CDPoint da, paint_options options, int dir)
 	{
 		AddExtent(CPoint(a.x - iHeight, a.y - x_pos));
 	}
-	
+
 
 
 	if (oldPen)
@@ -915,7 +915,7 @@ void CContext::PaintConnectPoint(CDPoint dp)
 	m_pDC->Ellipse(CRect(p.x + size, p.y + size, p.x - size, p.y - size));
 }
 
-void CContext::PaintTracker(CDRect &r)
+void CContext::PaintTracker(CDRect &r, bool handles)
 {
 	// Convert to normal
 	Transform t(m_Transform);
@@ -924,8 +924,12 @@ void CContext::PaintTracker(CDRect &r)
 	int q = 1;
 	rect.InflateRect(q, q, q, q);
 
-	// Put some handles around this object
-	CRectTracker tracker(rect, CRectTracker::dottedLine | CRectTracker::resizeOutside);
-	tracker.Draw(GetDC());
+	UINT style = CRectTracker::dottedLine;
+	if(handles){
+		// Put some handles around this object
+		 style |= CRectTracker::resizeOutside;
+	}
 
+	CRectTracker tracker(rect, style);
+	tracker.Draw(GetDC());
 }

--- a/src/Context.h
+++ b/src/Context.h
@@ -144,7 +144,7 @@ public:
 	void SetPixelOffset(CPoint &p);
 	inline double GetZoomPixelScale() const { return 1; }
 
-	// Change the transform by rotating it 
+	// Change the transform by rotating it
 	CDPoint SetTRM(CDPoint, CDPoint, int);
 	void EndTRM(CDPoint);
 	int RotateDir(int) const;
@@ -346,7 +346,7 @@ class CContext
 	void AddExtent(CRect p);
 
 public:
-	void PaintTracker(CDRect &r);
+	void PaintTracker(CDRect &r, bool handles);
 	void PaintConnectPoint(CDPoint p);
 
 	CContext(CWnd *, Transform); // Construction from window

--- a/src/DrawMetafile.cpp
+++ b/src/DrawMetafile.cpp
@@ -231,7 +231,6 @@ void CDrawMetaFile::LoadXML(CXMLReader &xml)
 
 void CDrawMetaFile::Paint(CContext &dc, paint_options options)
 {
-
 	CDPoint sma = m_point_a;
 	CDPoint smb = m_point_b;
 
@@ -239,14 +238,22 @@ void CDrawMetaFile::Paint(CContext &dc, paint_options options)
 	CRect rect = dc.GetTransform().Scale(drect);
 	int rotmir = dc.GetTransform().GetRotMir();
 
-	CTCImage *pImage = m_pDesign->GetOption().GetImage(m_metafile);
-	if (pImage)
-	{
-		pImage->Paint(*dc.GetDC(), rect, rotmir);
-	}
-	else
-	{
-		CTCImage::PaintInvalid(*dc.GetDC(), rect);
+	if (options == paint_options::draw_selectable) {
+
+		// Draw outline instead of drawing the whole image. Image would hide other
+		// selectable items drawn over the image.
+		PaintSelectable(dc);
+
+	} else {
+		CTCImage *pImage = m_pDesign->GetOption().GetImage(m_metafile);
+		if (pImage)
+		{
+			pImage->Paint(*dc.GetDC(), rect, rotmir);
+		}
+		else
+		{
+			CTCImage::PaintInvalid(*dc.GetDC(), rect);
+		}
 	}
 }
 

--- a/src/DrawMethod.cpp
+++ b/src/DrawMethod.cpp
@@ -311,7 +311,7 @@ void CDrawMethod::Rotate(CDPoint p, int ndir)
 
 int CDrawMethod::DoRotate(int olddir, int newdir)
 {
-	//New rotation=>2  3  4  
+	//New rotation=>2  3  4
 	//                  Old dir ..\/..
 	int table[] = {6, 3, 4, // 0 (Up)
 	               7, 2, 5, // 1 (Down)
@@ -468,7 +468,7 @@ CString CDrawMethod::GetField(int which)
 //-------------------------------------------------------------------------
 int CDrawMethod::GetFieldIndexByName(CString name, bool caseSensitive)
 {
-	// For now, this is a loop. If speed is an issue, maybe there should be 
+	// For now, this is a loop. If speed is an issue, maybe there should be
 	// a field name map index.
 	int i;
 	fieldCollection::iterator it;
@@ -876,21 +876,6 @@ void CDrawMethod::Load(CStream &archive)
 	ExtractSymbol(tr, method);
 }
 
-inline void swap(int &a, int &b)
-{
-	int sp;
-	sp = a;
-	a = b;
-	b = sp;
-}
-inline void swap(double &a, double &b)
-{
-	double sp;
-	sp = a;
-	a = b;
-	b = sp;
-}
-
 double CDrawMethod::DistanceFromPoint(CDPoint p)
 {
 	// Use fast cut-off to see if the bounding box is inside the intersection box
@@ -931,10 +916,10 @@ double CDrawMethod::DistanceFromPoint(CDPoint p)
 				nt = - (nt - tr.y / sy);
 				break;
 			case 2: // Left
-				swap(nt, nl);
+				std::swap(nt, nl);
 				break;
 			case 3: // Right
-				swap(nt, nl);
+				std::swap(nt, nl);
 				nt = - (nt - tr.y / sx);
 				break;
 		}
@@ -1004,18 +989,18 @@ BOOL CDrawMethod::IsInside(double left, double right, double top, double bottom)
 		switch (rotate & 3)
 		{
 			case 1: // Down
-				swap(nt, nb);
+				std::swap(nt, nb);
 				nt = - (nt - tr.y / sy);
 				nb = - (nb - tr.y / sy);
 				break;
 			case 2: // Left
-				swap(nt, nl);
-				swap(nb, nr);
+				std::swap(nt, nl);
+				std::swap(nb, nr);
 				break;
 			case 3: // Right
-				swap(nt, nl);
-				swap(nb, nr);
-				swap(nt, nb);
+				std::swap(nt, nl);
+				std::swap(nb, nr);
+				std::swap(nt, nb);
 				nt = - (nt - tr.y / sx);
 				nb = - (nb - tr.y / sx);
 				break;
@@ -1028,13 +1013,13 @@ BOOL CDrawMethod::IsInside(double left, double right, double top, double bottom)
 			{
 				nl = -nl + tr.x / sy;
 				nr = -nr + tr.x / sy;
-				swap(nl, nr);
+				std::swap(nl, nr);
 			}
 			else
 			{
 				nl = -nl + tr.x / sx;
 				nr = -nr + tr.x / sx;
-				swap(nl, nr);
+				std::swap(nl, nr);
 			}
 		}
 
@@ -1424,7 +1409,7 @@ void CDrawMethod::PaintHandles(CContext &dc)
 	{
 		// Put some handles around this object
 		CDRect r(m_point_a.x, m_point_a.y, m_point_b.x, m_point_b.y);
-		dc.PaintTracker(r);
+		dc.PaintTracker(r, true);
 	}
 }
 
@@ -1455,7 +1440,7 @@ int CDrawMethod::SetCursorEdit(CDPoint p)
 void CDrawMethod::AddReference(int min_ref, bool all_sheets)
 {
 	// Search the document for a gap in our references
-	// 
+	//
 	CString our_reference = GetSymbolData()->reference;
 	int ppp = GetSymbolData()->ppp;
 
@@ -1479,7 +1464,7 @@ void CDrawMethod::AddReference(int min_ref, bool all_sheets)
 			ObjType objType = pointer->GetType();
 			if (   (objType == xMethodEx3 || objType == xHierarchicalSymbol)
 				&& pointer != this
-				&& pMethod->HasRef()) 
+				&& pMethod->HasRef())
 			{
 				// Has this got the same reference as us?
 				if (pMethod->GetSymbolData()->reference == our_reference)

--- a/src/DrawRectOutline.cpp
+++ b/src/DrawRectOutline.cpp
@@ -40,7 +40,14 @@ void CDrawRectOutline::PaintHandles(CContext &dc)
 	// Put some handles around this object
 	CDRect r(m_point_a.x, m_point_a.y, m_point_b.x, m_point_b.y);
 
-	dc.PaintTracker(r);
+	dc.PaintTracker(r, true);
+}
+
+void CDrawRectOutline::PaintSelectable(CContext &dc)
+{
+	CDRect r(m_point_a.x, m_point_a.y, m_point_b.x, m_point_b.y);
+
+	dc.PaintTracker(r, false);
 }
 
 // Move fields of this object about
@@ -53,7 +60,7 @@ int CDrawRectOutline::IsInsideField(CDPoint p)
 	CRectTracker tracker(rect, CRectTracker::dottedLine | CRectTracker::resizeOutside);
 	int r = tracker.HitTest(q);
 
-	if (r == 8)
+	if (r == CRectTracker::hitMiddle)
 	{
 		r = 11;
 	}

--- a/src/DrawText.cpp
+++ b/src/DrawText.cpp
@@ -356,7 +356,7 @@ void CDrawText::MoveField(int w, CDPoint r)
 
 		if (original_box_width > 0)
 		{
-			FontStyle = m_pDesign->GetOptions()->ChangeFontSize(FontStyle, dir < 2 ? r.x : -r.y, 
+			FontStyle = m_pDesign->GetOptions()->ChangeFontSize(FontStyle, dir < 2 ? r.x : -r.y,
 				(original_width * target_box_width) / original_box_width );
 		}
 
@@ -462,18 +462,21 @@ void CDrawText::Paint(CContext &dc, paint_options options)
 	dc.SetTextColor(FontColour);
 	dc.TextOut(str, m_point_a, options, dir);
 
-	// Draw a little blob, so the user knows where it
-	// is stuck to
-	if (xtype == xLabelEx2)
-	{
+	if (xtype == xTextEx2) {
+		if (options == paint_options::draw_selectable) {
+			// Draw outline
+			PaintSelectable(dc);
+		}
+
+	} else if (xtype == xLabelEx2) {
+
+		// Draw a little blob, so the user knows where it is stuck to
 		dc.SelectBrush();
 		dc.SelectPen(PS_SOLID, 1, cBOLD);
 		dc.Rectangle(CDRect(m_point_a.x - 2, m_point_a.y - 2, m_point_a.x + 2, m_point_a.y + 2));
-	}
 
-	// Is this a bus name?
-	if (xtype == xBusNameEx)
-	{
+	} else if (xtype == xBusNameEx) {
+
 		switch (options)
 		{
 			case draw_selected:

--- a/src/DrawingObject.h
+++ b/src/DrawingObject.h
@@ -63,12 +63,12 @@ enum ObjType {
 	xLine = 32, xDash = 33, xText = 34, xCircle = 35, xSquare = 36, xArc = 37, xLineEx = 38, xTextEx = 39,
 	xCircleEx = 40, xSquareEx = 41, xArcEx = 42,
 
-	xLineEx2 = 43, xCircleEx2 = 44, xSquareEx2 = 45, xArcEx2 = 46, xMetaFile = 47, 
+	xLineEx2 = 43, xCircleEx2 = 44, xSquareEx2 = 45, xArcEx2 = 46, xMetaFile = 47,
 
 	xTag  = 48, xRuler = 49, xMethodEx3 = 50, xPolygon = 51,
 	xNoteText = 64,
 
-	xEditItem = 128, 
+	xEditItem = 128,
 	xDesignInformation2 = 129,
 	xMetaFiles = 130,
 	xOptions = 131,
@@ -105,10 +105,7 @@ public:
 	char m_segment; // Mode of current edit
 
 	CDrawingObject(CTinyCadDoc *pDesign);
-	virtual ~CDrawingObject()
-	{
-	} // The destructor
-
+	virtual ~CDrawingObject() = default;
 
 	CDPoint ReadPoint(CStream &);
 

--- a/src/Item.cpp
+++ b/src/Item.cpp
@@ -427,10 +427,10 @@ CDrawingObject* CDrawEditItem::GetClosestObject(CDPoint p)
 	CDrawingObject* inside_object = NULL;
 	double closest_distance = 100;
 
-	drawingIterator it = m_pDesign->GetDrawingBegin();
-	while (it != m_pDesign->GetDrawingEnd())
+	for(drawingIterator it = m_pDesign->GetDrawingBegin(); it != m_pDesign->GetDrawingEnd(); ++it)
 	{
 		CDrawingObject *pointer = *it;
+		if (pointer->GetType() == xMetaFile) continue;
 
 		double distance = pointer->DistanceFromPoint(p);
 		if (distance <= closest_distance)
@@ -444,9 +444,6 @@ CDrawingObject* CDrawEditItem::GetClosestObject(CDPoint p)
 		{
 			inside_object = pointer;
 		}
-
-		// Move pointer on
-		++it;
 	}
 
 	if (closest_object)
@@ -456,6 +453,20 @@ CDrawingObject* CDrawEditItem::GetClosestObject(CDPoint p)
 		if (closest_distance == 0 || closest_distance > 10.0 / (m_pDesign->GetTransform().GetZoomFactor()))
 		{
 			closest_object = inside_object;
+		}
+	}
+
+	if (!closest_object) {
+		// Nothing selected, check last the metaobjects (such as bitmap images)
+		for (drawingIterator it = m_pDesign->GetDrawingBegin(); it != m_pDesign->GetDrawingEnd(); ++it)
+		{
+			CDrawingObject *pointer = *it;
+			if (pointer->GetType() != xMetaFile) continue;
+
+			if (pointer->IsInside(p.x, p.x, p.y, p.y)) {
+				closest_object = pointer;
+				break;
+			}
 		}
 	}
 

--- a/src/LibraryView.cpp
+++ b/src/LibraryView.cpp
@@ -198,7 +198,6 @@ void CLibraryView::OnDraw(CDC* pDC)
 	int text_pos_x;
 	int text_col_width = 0;
 	CDPoint p;
-	CDPoint qq;
 
 	for (; it != pDoc->m_SymbolMap.end(); ++it)
 	{
@@ -228,10 +227,9 @@ void CLibraryView::OnDraw(CDC* pDC)
 		//TRACE("Symbol orientation = %d, raw symbol origin = %g/%g\n",orientation, p.x, p.y);
 
 		if (orientation >= 2)
-		{ //swap x and y coordinates
-			qq = p;
-			p.x = qq.y;
-			p.y = qq.x;
+		{
+			//swap x and y coordinates
+			std::swap(p.x, p.y);
 		}
 		//TRACE("Symbol orientation = %d, rotated symbol origin = %g/%g\n",orientation, p.x, p.y);
 
@@ -489,7 +487,7 @@ void CLibraryView::OnPrepareDC(CDC* pDC, CPrintInfo* pInfo)
 
 void CLibraryView::OnEndPrinting(CDC* pDC, CPrintInfo* pInfo)
 {
-	// TODO: Add your specialized code here and/or call the base class	
+	// TODO: Add your specialized code here and/or call the base class
 	CScrollView::OnEndPrinting(pDC, pInfo);
 }
 

--- a/src/Object.h
+++ b/src/Object.h
@@ -42,6 +42,8 @@ protected:
 	{
 	}
 
+	virtual void PaintSelectable(CContext &dc);
+
 	// Redraw this object (including the handles)
 	virtual void Display(BOOL erase = TRUE);
 	virtual void PaintHandles(CContext &dc);
@@ -653,23 +655,23 @@ public:
 	{
 		return m_number;
 	}
-	
+
 	CString GetPinName()
 	{
 		return m_str;
 	}
-	
+
 	CString Find(const TCHAR *);
 	int GetPart()
 	{
 		return m_part;
 	}
-	
+
 	int GetElec()
 	{
 		return m_elec;
 	}
-	
+
 	static const TCHAR *GetElectricalTypeName(int etype);
 
 	virtual UINT getMenuID()
@@ -771,11 +773,11 @@ public:
 	{
 		return m_type == xSquareEx3;
 	}
-	
+
 	// This is used for the construction of this object
 	CDrawSquare(CTinyCadDoc *pDesign, ObjType type);
 
-	virtual UINT getMenuID() 
+	virtual UINT getMenuID()
 	{
 		return IsSquare() ? IDM_TOOLSQUARE : IDM_TOOLCIRCLE;
 	}
@@ -843,7 +845,7 @@ public:
 	virtual ~CDrawNoteText()
 	{
 	}
-	virtual UINT getMenuID() 
+	virtual UINT getMenuID()
 	{
 		return IDM_TOOLNOTETEXT;
 	}
@@ -1153,8 +1155,8 @@ public:
 
 	enum FieldPos
 	{
-		Ref = 0, 
-		Name, 
+		Ref = 0,
+		Name,
 		Other
 	};
 

--- a/src/Polygon.cpp
+++ b/src/Polygon.cpp
@@ -809,7 +809,7 @@ void CDrawPolygon::PaintHandles(CContext&dc)
 	CalcBoundingRect();
 	CDRect r(m_point_a.x - OUTLINE_SPACER, m_point_a.y - OUTLINE_SPACER, m_point_b.x + OUTLINE_SPACER, m_point_b.y + OUTLINE_SPACER);
 
-	dc.PaintTracker(r);
+	dc.PaintTracker(r, true);
 }
 
 // Move fields of this object about
@@ -1032,7 +1032,7 @@ BOOL CDrawPolygon::IsInsidePolygon(CDPoint p)
 		if (l1.x == l2.x)
 		{
 			// Perform quick calculation
-			if (   p.y < min(l1.y,l2.y) 
+			if (   p.y < min(l1.y,l2.y)
 				|| p.y > max(l1.y,l2.y) )
 			{
 				continue;
@@ -1056,7 +1056,7 @@ BOOL CDrawPolygon::IsInsidePolygon(CDPoint p)
 		}
 
 		// Is this inside the line?
-		if (	x_intersect < min(l1.x,l2.x) 
+		if (	x_intersect < min(l1.x,l2.x)
 			||	x_intersect > max(l1.x,l2.x))
 		{
 			// No, so continue
@@ -1303,7 +1303,7 @@ double CDrawPolygon::DistanceFromPoint(CDPoint p)
 	// Use fast cut-off to see if the bounding box is inside the intersection box
 	// Use somewhat enlarged bounding box to allow DistanceFromPoint from just outside the bounding box
 	if ( ((m_point_a.x<p.x-10 && m_point_b.x<p.x-10) || (m_point_a.x>p.x+10 && m_point_b.x>p.x+10)
-	   || (m_point_a.y<p.y-10 && m_point_b.y<p.y-10) || (m_point_a.y>p.y+10 && m_point_b.y>p.y+10))) 
+	   || (m_point_a.y<p.y-10 && m_point_b.y<p.y-10) || (m_point_a.y>p.y+10 && m_point_b.y>p.y+10)))
 	{
 		return 100.0;
 	}
@@ -1393,7 +1393,7 @@ BOOL CDrawPolygon::IsInside(double left, double right, double top, double bottom
 		return TRUE;
 	}
 
-	// If we are filled or editing then check to see 
+	// If we are filled or editing then check to see
 	// if any of the four points are inside our polygon
 	if (Fill != fsNONE || m_re_edit || (left == right && top == bottom))
 	{

--- a/src/TinyCadRegistry.cpp
+++ b/src/TinyCadRegistry.cpp
@@ -75,7 +75,6 @@ CString CTinyCadRegistry::GetInstalledFileTime()
 	}
 	FILETIME ftCreate, ftAccess, ftWrite;
 	SYSTEMTIME stUTC, stLocal;
-	DWORD dwRet;
 
 	// Retrieve the file times for the file.
 	if (!GetFileTime(hFile, &ftCreate, &ftAccess, &ftWrite))


### PR DESCRIPTION
When mouse is moving check first everything else for selectability before metafiles. If nothing is selected only then check if cursor is inside any of the metafiles. Change makes a lot easier to select objects (especially wires) on top of images.

Selectable images are not drawn anymore over other objects but are merely outlined. Selectable text items are outlined for better user feedback.