### PR TITLE
Exchange Sheets, Revision, Document details titles

### DIFF
--- a/src/Details.cpp
+++ b/src/Details.cpp
@@ -402,12 +402,9 @@ void CDetails::DisplayBox(CContext& dc, COption& oOption, CString sPathName) con
 		dc.TextOut(tl.x + TextSpace, tl.y + LineHeight, _T("Title"));
 		dc.TextOut(tl.x + TextSpace, tl.y + LineHeight * 3, _T("Author"));
 		dc.TextOut(tl.x + TextSpace, tl.y + LineHeight * 6, _T("File"));
-//		dc.TextOut(tl.x + TextSpace, tl.y + LineHeight * 8, _T("Revision"));
 		dc.TextOut(tl.x + TextSpace, tl.y + LineHeight * 8, _T("Document"));
-//		dc.TextOut(MiddleRow + TextSpace, tl.y + LineHeight * 6, _T("Document"));
 		dc.TextOut(MiddleRow + TextSpace, tl.y + LineHeight * 6, _T("Sheets"));
 		dc.TextOut(tl.x + BottomRow + TextSpace, tl.y + LineHeight * 8, _T("Date"));
-//		dc.TextOut(MiddleRow + TextSpace, tl.y + LineHeight * 8, _T("Sheets"));
 		dc.TextOut(MiddleRow + TextSpace, tl.y + LineHeight * 8, _T("Revision"));
 
 		// Add the actual data!
@@ -420,10 +417,6 @@ void CDetails::DisplayBox(CContext& dc, COption& oOption, CString sPathName) con
 		dc.TextOut(tl.x + TextSpace * 2, tl.y + LineHeight * 7, static_cast<int> (MiddleRow - tl.x - TextSpace * 4), sPathName);
 
 
-//		dc.TextOut(tl.x + TextSpace * 2, tl.y + LineHeight * 9, m_sRevision);
-//		dc.TextOut(MiddleRow + TextSpace * 2, tl.y + LineHeight * 7, m_sDocNo);
-//		dc.TextOut(tl.x + BottomRow + TextSpace * 2, tl.y + LineHeight * 9, GetLastChange());
-//		dc.TextOut(MiddleRow + TextSpace * 2, tl.y + LineHeight * 9, m_sSheets);
 		dc.TextOut(tl.x + TextSpace * 2, tl.y + LineHeight * 9, m_sDocNo);
 		dc.TextOut(MiddleRow + TextSpace * 2, tl.y + LineHeight * 7, m_sSheets);
 		dc.TextOut(tl.x + BottomRow + TextSpace * 2, tl.y + LineHeight * 9, GetLastChange());

--- a/src/Details.cpp
+++ b/src/Details.cpp
@@ -402,10 +402,13 @@ void CDetails::DisplayBox(CContext& dc, COption& oOption, CString sPathName) con
 		dc.TextOut(tl.x + TextSpace, tl.y + LineHeight, _T("Title"));
 		dc.TextOut(tl.x + TextSpace, tl.y + LineHeight * 3, _T("Author"));
 		dc.TextOut(tl.x + TextSpace, tl.y + LineHeight * 6, _T("File"));
-		dc.TextOut(tl.x + TextSpace, tl.y + LineHeight * 8, _T("Revision"));
-		dc.TextOut(MiddleRow + TextSpace, tl.y + LineHeight * 6, _T("Document"));
+//		dc.TextOut(tl.x + TextSpace, tl.y + LineHeight * 8, _T("Revision"));
+		dc.TextOut(tl.x + TextSpace, tl.y + LineHeight * 8, _T("Document"));
+//		dc.TextOut(MiddleRow + TextSpace, tl.y + LineHeight * 6, _T("Document"));
+		dc.TextOut(MiddleRow + TextSpace, tl.y + LineHeight * 6, _T("Sheets"));
 		dc.TextOut(tl.x + BottomRow + TextSpace, tl.y + LineHeight * 8, _T("Date"));
-		dc.TextOut(MiddleRow + TextSpace, tl.y + LineHeight * 8, _T("Sheets"));
+//		dc.TextOut(MiddleRow + TextSpace, tl.y + LineHeight * 8, _T("Sheets"));
+		dc.TextOut(MiddleRow + TextSpace, tl.y + LineHeight * 8, _T("Revision"));
 
 		// Add the actual data!
 		dc.TextOut(tl.x + TextSpace * 2, tl.y + LineHeight * 2, m_sTitle);
@@ -417,10 +420,15 @@ void CDetails::DisplayBox(CContext& dc, COption& oOption, CString sPathName) con
 		dc.TextOut(tl.x + TextSpace * 2, tl.y + LineHeight * 7, static_cast<int> (MiddleRow - tl.x - TextSpace * 4), sPathName);
 
 
-		dc.TextOut(tl.x + TextSpace * 2, tl.y + LineHeight * 9, m_sRevision);
-		dc.TextOut(MiddleRow + TextSpace * 2, tl.y + LineHeight * 7, m_sDocNo);
+//		dc.TextOut(tl.x + TextSpace * 2, tl.y + LineHeight * 9, m_sRevision);
+//		dc.TextOut(MiddleRow + TextSpace * 2, tl.y + LineHeight * 7, m_sDocNo);
+//		dc.TextOut(tl.x + BottomRow + TextSpace * 2, tl.y + LineHeight * 9, GetLastChange());
+//		dc.TextOut(MiddleRow + TextSpace * 2, tl.y + LineHeight * 9, m_sSheets);
+		dc.TextOut(tl.x + TextSpace * 2, tl.y + LineHeight * 9, m_sDocNo);
+		dc.TextOut(MiddleRow + TextSpace * 2, tl.y + LineHeight * 7, m_sSheets);
 		dc.TextOut(tl.x + BottomRow + TextSpace * 2, tl.y + LineHeight * 9, GetLastChange());
-		dc.TextOut(MiddleRow + TextSpace * 2, tl.y + LineHeight * 9, m_sSheets);
+		dc.TextOut(MiddleRow + TextSpace * 2, tl.y + LineHeight * 9, m_sRevision);
+
 	}
 }
 //-------------------------------------------------------------------------

--- a/src/Details.cpp
+++ b/src/Details.cpp
@@ -402,9 +402,12 @@ void CDetails::DisplayBox(CContext& dc, COption& oOption, CString sPathName) con
 		dc.TextOut(tl.x + TextSpace, tl.y + LineHeight, _T("Title"));
 		dc.TextOut(tl.x + TextSpace, tl.y + LineHeight * 3, _T("Author"));
 		dc.TextOut(tl.x + TextSpace, tl.y + LineHeight * 6, _T("File"));
+//		dc.TextOut(tl.x + TextSpace, tl.y + LineHeight * 8, _T("Revision"));
 		dc.TextOut(tl.x + TextSpace, tl.y + LineHeight * 8, _T("Document"));
+//		dc.TextOut(MiddleRow + TextSpace, tl.y + LineHeight * 6, _T("Document"));
 		dc.TextOut(MiddleRow + TextSpace, tl.y + LineHeight * 6, _T("Sheets"));
 		dc.TextOut(tl.x + BottomRow + TextSpace, tl.y + LineHeight * 8, _T("Date"));
+//		dc.TextOut(MiddleRow + TextSpace, tl.y + LineHeight * 8, _T("Sheets"));
 		dc.TextOut(MiddleRow + TextSpace, tl.y + LineHeight * 8, _T("Revision"));
 
 		// Add the actual data!
@@ -417,6 +420,10 @@ void CDetails::DisplayBox(CContext& dc, COption& oOption, CString sPathName) con
 		dc.TextOut(tl.x + TextSpace * 2, tl.y + LineHeight * 7, static_cast<int> (MiddleRow - tl.x - TextSpace * 4), sPathName);
 
 
+//		dc.TextOut(tl.x + TextSpace * 2, tl.y + LineHeight * 9, m_sRevision);
+//		dc.TextOut(MiddleRow + TextSpace * 2, tl.y + LineHeight * 7, m_sDocNo);
+//		dc.TextOut(tl.x + BottomRow + TextSpace * 2, tl.y + LineHeight * 9, GetLastChange());
+//		dc.TextOut(MiddleRow + TextSpace * 2, tl.y + LineHeight * 9, m_sSheets);
 		dc.TextOut(tl.x + TextSpace * 2, tl.y + LineHeight * 9, m_sDocNo);
 		dc.TextOut(MiddleRow + TextSpace * 2, tl.y + LineHeight * 7, m_sSheets);
 		dc.TextOut(tl.x + BottomRow + TextSpace * 2, tl.y + LineHeight * 9, GetLastChange());


### PR DESCRIPTION
Moves "Document" to space for "Revision", allows room for longer document names. Places "Revision" in the corner and "Sheets" above it. 

Original (current code)
![image](https://user-images.githubusercontent.com/286883/208970078-2cc96482-924c-42ff-8e95-694b2b247080.png)

Patched code: 
![image](https://user-images.githubusercontent.com/286883/208970171-e97e86fa-d439-41cc-8562-332226ed3266.png)
