### PR TITLE
Normal label spacing

### DIFF
--- a/src/DrawLabel.cpp
+++ b/src/DrawLabel.cpp
@@ -433,19 +433,23 @@ void CDrawLabel::CalcLayout()
 	}
 	else
 	{
-		m_point_a = m_active_point;
+		const double spacing = size.cy / 5;
 		switch (dir)
 		{
 			case 0: // Up
+				m_point_a = CDPoint(m_active_point.x, m_active_point.y - spacing);
 				m_point_b = CDPoint(m_point_a.x - size.cy, m_point_a.y - size.cx);
 				break;
 			case 1: // Down
+				m_point_a = CDPoint(m_active_point.x, m_active_point.y + spacing);
 				m_point_b = CDPoint(m_point_a.x - size.cy, m_point_a.y + size.cx);
 				break;
 			case 2: // Left
+				m_point_a = CDPoint(m_active_point.x - spacing, m_active_point.y);
 				m_point_b = CDPoint(m_point_a.x - size.cx, m_point_a.y - size.cy);
 				break;
 			case 3: // Right
+				m_point_a = CDPoint(m_active_point.x + spacing, m_active_point.y);
 				m_point_b = CDPoint(m_point_a.x + size.cx, m_point_a.y - size.cy);
 				break;
 		}


### PR DESCRIPTION
Add some spacing on normal labels. Labels are mostly used next to wires and currently drawn so tight that readability suffers.
Comparison of master and pull request.
![label_align_pr](https://user-images.githubusercontent.com/380448/220288910-7e9d7eae-e069-48a5-a89d-3ab2421aaee4.png)
![label_align_master](https://user-images.githubusercontent.com/380448/220288923-7166d9ff-413e-40ed-8768-5fdc435240c6.png)
