### PR TITLE
Make CNetList.WriteSpiceFile emit model code for each component.

### DIFF
--- a/src/NetList.cpp
+++ b/src/NetList.cpp
@@ -3217,7 +3217,8 @@ void CNetList::WriteSpiceFile(CTinyCadMultiDoc *pDesign, const TCHAR *filename)
 
 		if (!spice.IsEmpty())
 		{
-			CString temp;
+			CString temp = expand_spice(file_name_index, sheet, symbol, labels, preferredLabel, spice);
+
 			_ftprintf(theFile, _T("%s\n"), (LPCTSTR)temp);
 		}
 		else


### PR DESCRIPTION
The "Create Spice Netlist" feature was emitting spice code for the prologue and epilogue for each symbol type, but wasn't emitting the "model" spice code for each symbol.  It looks like CString temp in NetList.cpp line 3220 just never got set.